### PR TITLE
default y BUSYBOX_DEFAULT_FEATURE_TOUCH_NODEREF

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -810,7 +810,7 @@ config BUSYBOX_DEFAULT_TOUCH
 	default y
 config BUSYBOX_DEFAULT_FEATURE_TOUCH_NODEREF
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_FEATURE_TOUCH_SUSV3
 	bool
 	default y


### PR DESCRIPTION
To make entware-ng more compatible with Padavan firmware, and solve its `mtd_storage.sh save` "touch: invalid option -- h" issue: https://bitbucket.org/padavan/rt-n56u/issues/389/with-installed-busybox-mtd_storagesh

Root cause: Padavan firmware links busybox utilities to pathless busybox instead of the explicit firmware /bin/busybox

-------------------------------

Compile tested: (put here arch, model, version)
Run tested: (put here arch, model, version, tests done)
